### PR TITLE
hotfix/Security_antMatchers

### DIFF
--- a/src/main/java/com/maptravel/maptravel/config/SecurityConfig.java
+++ b/src/main/java/com/maptravel/maptravel/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.maptravel.maptravel.oauth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -37,9 +38,11 @@ public class SecurityConfig {
         .csrf().disable()
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))
         .sessionManagement(sessionManagement ->
-            sessionManagement.sessionCreationPolicy(SessionCreationPolicy.NEVER))
+            sessionManagement.sessionCreationPolicy(
+                SessionCreationPolicy.NEVER))
         .authorizeRequests(auth -> auth
-            .antMatchers("/**").permitAll()
+            .antMatchers("/v1/signup", "/v1/signin", "/v1/token/refresh").permitAll()
+            .antMatchers(HttpMethod.GET, "/v1/plane/**").permitAll()
             .anyRequest().authenticated()
         )
         .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),


### PR DESCRIPTION
# Security_antMatchers
- 회원가입, 로그인, 토큰 재발급 경로만 Filter 통과하도록 설정
- Plane의 경우 GET 요청만 통과하도록 설정