### PR TITLE
hotfix/DeletePlane Likes,Bookmark

### DIFF
--- a/src/main/java/com/maptravel/maptravel/domain/repository/BookmarkRepository.java
+++ b/src/main/java/com/maptravel/maptravel/domain/repository/BookmarkRepository.java
@@ -13,4 +13,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
   Optional<Bookmark> findByUserIdAndPlaneId(Long userId, Long planeId);
 
   Page<Bookmark> findAllByUserId(Long id, Pageable pageable);
+
+  void deleteAllByPlaneId(Long planeId);
 }

--- a/src/main/java/com/maptravel/maptravel/domain/repository/LikesRepository.java
+++ b/src/main/java/com/maptravel/maptravel/domain/repository/LikesRepository.java
@@ -15,4 +15,6 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
   Page<Likes> findAllByUserId(Long id, Pageable pageable);
 
   Long countByPlaneId(Long planeId);
+
+  void deleteAllByPlaneId(Long planeId);
 }

--- a/src/main/java/com/maptravel/maptravel/service/PlaneService.java
+++ b/src/main/java/com/maptravel/maptravel/service/PlaneService.java
@@ -138,6 +138,9 @@ public class PlaneService {
       }
     });
 
+    likesRepository.deleteAllByPlaneId(planeId);
+    bookmarkRepository.deleteAllByPlaneId(planeId);
+
     planeRepository.delete(plane);
   }
 

--- a/src/test/java/com/maptravel/maptravel/controller/PlaneControllerTest.java
+++ b/src/test/java/com/maptravel/maptravel/controller/PlaneControllerTest.java
@@ -16,11 +16,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.maptravel.maptravel.domain.constants.RoleType;
+import com.maptravel.maptravel.domain.entity.Bookmark;
+import com.maptravel.maptravel.domain.entity.Likes;
 import com.maptravel.maptravel.domain.entity.Place;
 import com.maptravel.maptravel.domain.entity.Plane;
 import com.maptravel.maptravel.domain.entity.User;
 import com.maptravel.maptravel.domain.form.CreatePlaceForm;
 import com.maptravel.maptravel.domain.form.CreatePlaneForm;
+import com.maptravel.maptravel.domain.repository.BookmarkRepository;
+import com.maptravel.maptravel.domain.repository.LikesRepository;
 import com.maptravel.maptravel.domain.repository.PlaceRepository;
 import com.maptravel.maptravel.domain.repository.PlaneRepository;
 import com.maptravel.maptravel.domain.repository.UserRepository;
@@ -63,6 +67,12 @@ class PlaneControllerTest {
   private PlaceRepository placeRepository;
 
   @Autowired
+  private LikesRepository likesRepository;
+
+  @Autowired
+  private BookmarkRepository bookmarkRepository;
+
+  @Autowired
   private JwtTokenProvider jwtTokenProvider;
 
   private final String url = "http://localhost:8080";
@@ -73,6 +83,8 @@ class PlaneControllerTest {
 
   @AfterEach
   void init() {
+    likesRepository.deleteAll();
+    bookmarkRepository.deleteAll();
     placeRepository.deleteAll();
     planeRepository.deleteAll();
     userRepository.deleteAll();
@@ -323,6 +335,15 @@ class PlaneControllerTest {
         .address("placeAddress")
         .pictureListUrl("[\"" + PICTURE + "\"]")
         .plane(plane)
+        .build());
+
+    likesRepository.save(Likes.builder()
+        .plane(plane)
+        .user(user)
+        .build());
+    bookmarkRepository.save(Bookmark.builder()
+        .plane(plane)
+        .user(user)
         .build());
 
     mockMvc.perform(


### PR DESCRIPTION
## DeletePlane
- 여행 삭제 시 좋아요, 북마크가 참조되어 있어 삭제가 안 됨 -> 삭제 직전 좋아요와 북마크 삭제하는 로직 추가